### PR TITLE
Solved issue with edge case in reading data

### DIFF
--- a/R/parseFiles.R
+++ b/R/parseFiles.R
@@ -52,9 +52,10 @@ parse_metaphlan_list <- function(sample_id, file_path, data_type) {
                               "reads_processed")
 
         ## Read remainder of output file
-        load_file <- readr::read_tsv(file_path, skip = 4)
-        colnames(load_file) <- c("clade_name", "ncbi_tax_id",
-                                 "relative_abundance", "additional_species")
+        load_file <- readr::read_tsv(file_path, skip = 4, 
+                                     col_names = c("clade_name", "ncbi_tax_id",
+                                                                        "relative_abundance", "additional_species"), 
+                                     col_types = c("factor", "factor", "double", "factor"))
 
         ## Separate out row data
         rdata_cols <- c("ncbi_tax_id", "additional_species")
@@ -113,7 +114,7 @@ parse_metaphlan_list <- function(sample_id, file_path, data_type) {
 
     ## Combine process metadata, row data, sample ID, and assays into
     ## SummarizedExperiment object
-    ex <- SummarizedExperiment::SummarizedExperiment(assays = alist,
+    ex <- TreeSummarizedExperiment::::TreeSummarizedExperiment(assays = alist,
                                                      rowData = rdata,
                                                      colData = cdata,
                                                      metadata = meta_list)

--- a/R/parseFiles.R
+++ b/R/parseFiles.R
@@ -114,7 +114,7 @@ parse_metaphlan_list <- function(sample_id, file_path, data_type) {
 
     ## Combine process metadata, row data, sample ID, and assays into
     ## SummarizedExperiment object
-    ex <- TreeSummarizedExperiment::::TreeSummarizedExperiment(assays = alist,
+    ex <- SummarizedExperiment::SummarizedExperiment(assays = alist,
                                                      rowData = rdata,
                                                      colData = cdata,
                                                      metadata = meta_list)

--- a/R/parseFiles.R
+++ b/R/parseFiles.R
@@ -52,10 +52,10 @@ parse_metaphlan_list <- function(sample_id, file_path, data_type) {
                               "reads_processed")
 
         ## Read remainder of output file
-        load_file <- readr::read_tsv(file_path, skip = 4, 
+        load_file <- readr::read_tsv(file_path, skip = 5, 
                                      col_names = c("clade_name", "ncbi_tax_id",
                                                                         "relative_abundance", "additional_species"), 
-                                     col_types = c("factor", "factor", "double", "factor"))
+                                     col_types = "ffdf")
 
         ## Separate out row data
         rdata_cols <- c("ncbi_tax_id", "additional_species")

--- a/R/parseFiles.R
+++ b/R/parseFiles.R
@@ -55,7 +55,7 @@ parse_metaphlan_list <- function(sample_id, file_path, data_type) {
         load_file <- readr::read_tsv(file_path, skip = 5, 
                                      col_names = c("clade_name", "ncbi_tax_id",
                                                                         "relative_abundance", "additional_species"), 
-                                     col_types = "ffdf")
+                                     col_types = cols("factor", "factor", "double", "factor"))
 
         ## Separate out row data
         rdata_cols <- c("ncbi_tax_id", "additional_species")


### PR DESCRIPTION
This addition helps the user against exceptions due to 100% unmapped/unassigned reads in metaphlan data parsing. 
Examples of these are uuids: 
01794762-d90d-456d-a575-f6445983e0a9
e3a55567-afd0-40d8-9f0a-8f1594b3a733
