### PR TITLE
Functions for retrieving information from parquet files

### DIFF
--- a/R/readParquet.R
+++ b/R/readParquet.R
@@ -118,11 +118,18 @@ filter_parquet <- function(con, db_table, filter_column, filter_string) {
 
     #return(set)
 
-    set <- tbl(con, db_table) |>
-        filter(grepl(filter_string, .data[[filter_column]])) |>
-        collect()
+    set <- dplyr::tbl(con, db_table) |>
+        dplyr::filter(grepl(filter_string, .data[[filter_column]])) |>
+        dplyr::collect()
 
     return(set)
+}
+
+load_parquet <- function(con, db_table) {
+    tb <- dplyr::tbl(con, db_table) |>
+        dplyr::collect()
+
+    return(tb)
 }
 
 transform_parquet <- function(parquet_table, data_type) {
@@ -139,8 +146,8 @@ transform_parquet <- function(parquet_table, data_type) {
         rowwise() %>%
         mutate(uuid = unlist(strsplit(filename, "/"))[6]) %>%
         select(-filename) %>%
-        pivot_wider(names_from = uuid, values_from = out_Coverage) %>%
-        column_to_rownames("pathway")
+        tidyr::pivot_wider(names_from = uuid, values_from = out_Coverage) %>%
+        column_to_rownames("# Pathway")
 
     ## Separate out row data
     rdata <- S4Vectors::DataFrame(matrix(nrow = nrow(se), ncol = 0))

--- a/R/readParquet.R
+++ b/R/readParquet.R
@@ -58,9 +58,10 @@
 #' @export
 #' @importFrom DBI dbConnect dbExecute
 #' @importFrom duckdb duckdb
-db_connect <- function() {
+db_connect <- function(dbdir = ":memory:") {
     ## Establish DuckDB connection and confirm that httpfs is installed
-    con <- DBI::dbConnect(duckdb::duckdb(dbdir = "curatedMetagenomicData.duckdb"))
+    con <- DBI::dbConnect(duckdb::duckdb(), dbdir = dbdir)
+    #con <- DBI::dbConnect(duckdb::duckdb(dbdir = "curatedMetagenomicData.duckdb"))
     DBI::dbExecute(con, "INSTALL httpfs")
 
     return(con)
@@ -80,10 +81,10 @@ db_connect <- function() {
 #' }
 #' @seealso
 #'  \code{\link[DBI]{dbExecute}}
-#' @rdname access_parquet
+#' @rdname view_parquet
 #' @export
 #' @importFrom DBI dbExecute
-access_parquet <- function(con, data_type = "pathcoverage_unstratified") {
+view_parquet <- function(con, data_type = "pathcoverage_unstratified") {
     ## Create data_type-specific view
     statement <- paste0("CREATE VIEW IF NOT EXISTS ", data_type,
                         " AS (SELECT * FROM read_parquet('hf://datasets/waldronlab/metagenomics_mac/",
@@ -91,7 +92,72 @@ access_parquet <- function(con, data_type = "pathcoverage_unstratified") {
     DBI::dbExecute(con, statement)
 
     ## Notify of success
-    print(paste0("Data view can be found at '", data_type, "'"))
+    message(paste0("Data view can be found at '", data_type, "'"))
+}
+
+retrieve_all <- function(con) {
+    ## Get all data types
+    data_types <- output_file_types()$data_type
+
+    ## Create view for each type if it exists
+    for (type in data_types) {
+        test_url <- paste0("https://huggingface.co/datasets/waldronlab/metagenomics_mac/resolve/main/", type, ".parquet")
+        exists <- RCurl::url.exists(test_url)
+        if (!exists) {
+            message(paste0("'", type, "' is not currently available in the dataset waldronlab/metagenomics_mac, skipping."))
+            next
+        }
+        view_parquet(con, type)
+    }
+}
+
+filter_parquet <- function(con, db_table, filter_column, filter_string) {
+    ## Build and execute query
+    #statement <- paste0("SELECT * FROM ", db_table, " WHERE ", filter_column, " LIKE '%", filter_string, "%';")
+    #set <- DBI::dbGetQuery(con, statement)
+
+    #return(set)
+
+    set <- tbl(con, db_table) |>
+        filter(grepl(filter_string, .data[[filter_column]])) |>
+        collect()
+
+    return(set)
+}
+
+transform_parquet <- function(parquet_table, data_type) {
+    #transformed <- preview %>%
+    #    mutate(uuid = unlist(strsplit(filename, "/"))[6])
+
+    #raw <- tbl(con, "pathcoverage_unstratified") |> collect()
+    #colnames(raw)[1] <- "pathway"
+
+    ## Get parameters by data type
+
+    ## Expand parquet by filename
+    se <- parquet_table %>%
+        rowwise() %>%
+        mutate(uuid = unlist(strsplit(filename, "/"))[6]) %>%
+        select(-filename) %>%
+        pivot_wider(names_from = uuid, values_from = out_Coverage) %>%
+        column_to_rownames("pathway")
+
+    ## Separate out row data
+    rdata <- S4Vectors::DataFrame(matrix(nrow = nrow(se), ncol = 0))
+    rownames(rdata) <- rownames(se)
+
+    ## Set sample ID as column name
+    cdata <- S4Vectors::DataFrame(matrix(nrow = ncol(se), ncol = 0))
+    rownames(cdata) <- colnames(se)
+
+    ## Set relative abundance as assay
+    upcoverage <- as.matrix(se)
+    alist <- list(upcoverage)
+    names(alist) <- "pathcoverage_unstratified"
+
+    ex <- SummarizedExperiment::SummarizedExperiment(assays = alist,
+                                                     rowData = rdata,
+                                                     colData = cdata)
 }
 
 


### PR DESCRIPTION
- Adapted code to work from in-memory database
- New functions:
- retrieve_all - creates database views for all available data types at once
- filter_parquet - apply string matching filter to specified parquet column before loading (planning to expand to other filtering methods)
- load_parquet - simple function to load entire parquet file
- transform_parquet - convert parquet file to Summarized Experiment object (currently hard-coded to work with “pathcoverage_unstratified” data type, will add functionality for others)


