### PR TITLE
Fixed mistake + unwanted changes in PR #114

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: Artistic-2.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-Depends: R (>= 4.5.2)
+Depends: R (>= 4.6.0)
 Imports:
     dplyr,
     tidyr,

--- a/vignettes/first-15-minutes.Rmd
+++ b/vignettes/first-15-minutes.Rmd
@@ -7,14 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r knitr setup, include=FALSE}
+```{r knitr_setup, include=FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
     comment = "#>"
 )
 ```
 
-```{r general setup, include=FALSE}
+```{r general_setup, include=FALSE}
 library(parkinsonsMetagenomicData)
 library(TreeSummarizedExperiment)
 library(dplyr)
@@ -52,10 +52,10 @@ This vignette is a fast path to retrieving microbiome data as a
 
 ## Quick start
 
-You can view metadata about all samples in `sampleMetaData`. Later in example 1, you'll see how to filter rows 
+You can view metadata about all samples in `sampleMetadata`. Later in example 1, you'll see how to filter rows 
 of this table to choose which samples you want to download data for. 
 
-```{r load sample metadata}
+```{r load_sample_metadata}
 data("sampleMetadata", package = "parkinsonsMetagenomicData")
 dim(sampleMetadata)
 
@@ -66,11 +66,11 @@ as_tibble(sampleMetadata[1:5, 1:10])
 
 Before retrieving data, you can explore what data types are available. Each data type represents different measurements or processing levels from various bioinformatics tools:
 
-```{r explore data types}
+```{r explore_data_types}
 available_data <- get_hf_parquet_urls()
 ```
 
-```{r show data_types, echo=FALSE}
+```{r show_data_types, echo=FALSE}
 library(DT)
 get_hf_parquet_urls() |>
     select(data_type, tool, description, units_normalization) |>
@@ -90,7 +90,7 @@ Use the search boxes above each column to filter by data type, tool, or keywords
 
 Fetch MetaPhlAn4 relative abundance data for all Faecalibacterium species across all samples in the ZhangM_2023 study, directly from remote storage:
 
-```{r quick start}
+```{r quick_start}
 # In any subset of samples there will be many columns of all NA,
 # so the select function below is usually wanted.
 sample_table <- sampleMetadata |>
@@ -122,12 +122,12 @@ downloading from a remote repo.
 
 You can also retrieve functional data like metabolic pathways. First, discover which reference tables are available:
 
-```{r discover refs}
+```{r discover_refs}
 # See what reference tables are available
 ref_info <- get_ref_info()
 ```
 
-```{r show ref_info, echo=FALSE}
+```{r show_ref_info, echo=FALSE}
 get_ref_info() |>
     datatable(
         options = list(pageLength = 10),
@@ -138,7 +138,7 @@ get_ref_info() |>
 
 Now load the pathway reference and browse for pathways of interest:
 
-```{r browse pathways}
+```{r browse_pathways}
 # Load the pathway reference
 pathway_ref <- load_ref("pathway_ref")
 
@@ -155,7 +155,7 @@ butyrate_pathways
 Now fetch the abundance of a specific butyrate biosynthesis pathway across all 
 `r nrow(sampleMetadata)` samples in parkinsonsMetagenomicData:
 
-```{r pathway example}
+```{r pathway_example}
 # Use all samples (no filtering by study)
 # Select the acetyl-CoA fermentation to butanoate pathway
 feature_table_pathway <- pathway_ref |>
@@ -184,7 +184,7 @@ locally, which is covered in the `Piecewise Workflow` vignette.
 Both examples return a `TreeSummarizedExperiment` object with assays, sample 
 metadata, and feature metadata:
 
-```{r inspect result, eval=interactive()}
+```{r inspect_result, eval=interactive()}
 # Inspect the taxonomic data from Example 1
 assayNames(tse)
 head(colData(tse)) # Rownames are sample unique identifiers (UUIDs)
@@ -217,6 +217,6 @@ If `returnSamples` fails:
 - Nextflow pipeline for processing metagenomic data: [curatedMetagenomicsNextflow](https://github.com/seandavi/curatedMetagenomicsNextflow/)
 - Datasets found in the literature and efforts to obtain them: [parkinsons_data_search](https://github.com/ASAP-MAC/parkinsons_data_search)
 
-```{r session info}
+```{r session_info}
 sessionInfo()
 ```


### PR DESCRIPTION
I hope this solves the notes done on PR 114. Thank you for pointing them out.

- unwanted change: DESCRIPTION now has R >= 4.6.0 again. This was a workaround for me to install the package and test the vignettes

- mistake: I had changed `First 15 minutes` vignette's chunk names replacing underscores with spaces, not knowing that this triggers a note in Bioconductor checks.

Now they should be back on track.

------- Typo ---------
`sampleMetaData` --> `sampleMetadata`
