### PR TITLE
docs: integrate new vignettes for data preparation and file types

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,20 @@
 url: https://asap-mac.github.io/parkinsonsMetagenomicData/
 template:
   bootstrap: 5
-
+articles:
+  - title: "Getting Started"
+    desc: "Start here to learn how to access data."
+    contents:
+      - first-15-minutes
+      - full-workflow
+      - piecewise-workflow
+  - title: "Data Reference"
+    desc: "Documentation of the package's data schemas and formats."
+    contents:
+      - codebook
+      - file-types
+  - title: "Advanced Topics"
+    desc: "Details on generating the data and handling large files."
+    contents:
+      - full-data-preparation
+      - working-with-large-parquet-files

--- a/vignettes/file-types.Rmd
+++ b/vignettes/file-types.Rmd
@@ -261,7 +261,7 @@ subdivided or not based on the contributions of individual species. The
 abundance values are reported as reads per kilobase (RPK), counts per million
 (CPM), or relative abundance. The base HUMAnN calls to obtain these files are:
 
-```{base ex_genefam_call}
+```{bash ex_genefam_call}
 # Base call; outputs values in RPK
 $ humann \
         --input metagenome.fastq \
@@ -329,7 +329,7 @@ subdivided or not based on the contributions of individual species. The
 abundance values are reported as reads per kilobase (RPK), counts per million
 (CPM), or relative abundance. The base HUMAnN calls to obtain these files are:
 
-```{base ex_pathab_call}
+```{bash ex_pathab_call}
 # Base call; outputs values in RPK
 $ humann \
         --input metagenome.fastq \
@@ -396,7 +396,7 @@ file type can be stratified or unstratified, meaning the coverage values are
 subdivided or not based on the contributions of individual species. The base
 HUMAnN calls to obtain these files are:
 
-```{base ex_pathcov_call}
+```{bash ex_pathcov_call}
 # Base call
 $ humann \
         --input metagenome.fastq \

--- a/vignettes/first-15-minutes.Rmd
+++ b/vignettes/first-15-minutes.Rmd
@@ -30,6 +30,8 @@ This vignette is a fast path to retrieving microbiome data as a
 | Vignette | Audience | Typical time | Use when |
 |---|---|---:|---|
 | `Data Codebook` | All users | Reference | You need to understand variable definitions, data types, and column structures |
+| `Available File Types` | All users | Reference | You want to understand the structure, columns, and examples of raw pipeline output files |
+| `Full Data Preparation` | Advanced users/Developers | Reference | You want to understand how raw sequences were processed, transformed into Parquet files, and how metadata was curated |
 | `First 15 Minutes` | New users, biology-first workflows | 10-15 min | You want your first successful data retrieval quickly |
 | `Full Workflow` | Intermediate/advanced users | 30-45 min | You want full control over sample, feature, and query setup |
 | `Piecewise Workflow` | Advanced users | 30-60 min | You need direct control of `accessParquetData()` and `loadParquetData()` |


### PR DESCRIPTION
Integrates the `file-types.Rmd` and `full-data-preparation.Rmd` vignettes. 

- Fixes code block syntax issues in `file-types.Rmd` (`base` -> `bash`).
- Updates the vignette guide table in `first-15-minutes.Rmd` to include the new guides.
- Categorizes all vignettes logically in `_pkgdown.yml` for improved site navigation.