### PR TITLE
fix: convert_to_filter_values list assignment bug

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -577,7 +577,7 @@ convert_to_filter_values <- function(con, data_type, sample_data,
         for (i in seq_along(fcols)) {
             cur_col <- fcols[i]
             names(fsets)[i] <- cur_col
-            fsets[i] <- as.vector(unique(feature_data[,cur_col]))
+            fsets[[i]] <- as.vector(unique(feature_data[,cur_col]))
         }
 
         filter_values <- c(filter_values, fsets)

--- a/R/utils.R
+++ b/R/utils.R
@@ -577,7 +577,7 @@ convert_to_filter_values <- function(con, data_type, sample_data,
         for (i in seq_along(fcols)) {
             cur_col <- fcols[i]
             names(fsets)[i] <- cur_col
-            fsets[[i]] <- as.vector(unique(feature_data[,cur_col]))
+            fsets[[i]] <- as.vector(unique(feature_data[[cur_col]]))
         }
 
         filter_values <- c(filter_values, fsets)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -218,12 +218,21 @@ test_that("standardize_ordering correctly orders strings", {
 ## convert_to_filter_values
 test_that("convert_to_filter_values correctly handles multiple feature values", {
     feature_df <- data.frame(feature_col = c("feat1", "feat2", "feat3"))
-    sample_df <- data.frame(uuid = c("uuid1", "uuid2"))
 
+    # Test with standard data.frame
     filters <- convert_to_filter_values(con = NULL, data_type = "relative_abundance",
-                                        sample_data = sample_df, feature_data = feature_df)
+                                        sample_data = NULL, feature_data = feature_df)
 
     expect_equal(length(filters$feature_col), 3)
     expect_equal(filters$feature_col, c("feat1", "feat2", "feat3"))
-    expect_equal(length(filters$uuid), 2)
+    expect_null(filters$uuid)
+
+    # Test with tibble
+    feature_tibble <- tibble::as_tibble(feature_df)
+    filters_tibble <- convert_to_filter_values(con = NULL, data_type = "relative_abundance",
+                                               sample_data = NULL, feature_data = feature_tibble)
+
+    expect_equal(length(filters_tibble$feature_col), 3)
+    expect_equal(filters_tibble$feature_col, c("feat1", "feat2", "feat3"))
+    expect_null(filters_tibble$uuid)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -214,3 +214,16 @@ test_that("standardize_ordering correctly orders strings", {
 
     expect_equal(new_vec, expect_vec)
 })
+
+## convert_to_filter_values
+test_that("convert_to_filter_values correctly handles multiple feature values", {
+    feature_df <- data.frame(feature_col = c("feat1", "feat2", "feat3"))
+    sample_df <- data.frame(uuid = c("uuid1", "uuid2"))
+
+    filters <- convert_to_filter_values(con = NULL, data_type = "relative_abundance",
+                                        sample_data = sample_df, feature_data = feature_df)
+
+    expect_equal(length(filters$feature_col), 3)
+    expect_equal(filters$feature_col, c("feat1", "feat2", "feat3"))
+    expect_equal(length(filters$uuid), 2)
+})


### PR DESCRIPTION
When processing `feature_data` into filter lists, the use of single bracket assignment (`fsets[i] <- `) silently truncated vectors to a single item due to how R handles list element assignment. Changing it to double bracket (`fsets[[i]] <- `) correctly allows vectors of arbitrary length.

Also includes a unit test in `test-utils.R` verifying that `convert_to_filter_values` processes multiple elements properly without truncating.